### PR TITLE
Fix inconsistent button padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,8 @@
     const whatsappSection = document.getElementById("whatsappSection");
 
     let defaultYesSize = 5; // in vw
+    let defaultVerticalPadding = 2; // in vw
+    const verticalPaddingRatio = defaultVerticalPadding / defaultYesSize;
     let yesSize = defaultYesSize;
 
     noBtn.addEventListener("click", () => {
@@ -122,14 +124,14 @@
       } else {
         yesSize += 1.5;
         yesBtn.style.fontSize = `${yesSize}vw`;
-        yesBtn.style.padding = `${yesSize / 2}vw ${yesSize}vw`;
+        yesBtn.style.padding = `${yesSize * verticalPaddingRatio}vw ${yesSize}vw`;
       }
     });
 
-    yesBtn.addEventListener("click", () => {
-      yesSize = defaultYesSize;
-      yesBtn.style.fontSize = `${yesSize}vw`;
-      yesBtn.style.padding = `${yesSize / 2}vw ${yesSize}vw`;
+      yesBtn.addEventListener("click", () => {
+        yesSize = defaultYesSize;
+        yesBtn.style.fontSize = `${yesSize}vw`;
+        yesBtn.style.padding = `${yesSize * verticalPaddingRatio}vw ${yesSize}vw`;
 
       moveToNextQuestion();
     });


### PR DESCRIPTION
## Summary
- maintain original padding ratio when growing/shrinking the `Evet` button

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6852f325d3b0832da089e7e0e5e7320b